### PR TITLE
Fix lib path for MoltenVK

### DIFF
--- a/development/compiling/compiling_for_osx.rst
+++ b/development/compiling/compiling_for_osx.rst
@@ -69,7 +69,7 @@ editor binary built with ``target=release_debug``::
 If you are building the ``master`` branch, additionally copy the Vulkan library::
 
     mkdir -p Godot.app/Contents/Frameworks
-    cp <Vulkan SDK path>/macOS/libs/libMoltenVK.dylib Godot.app/Contents/Frameworks/libMoltenVK.dylib
+    cp <Vulkan SDK path>/macOS/lib/libMoltenVK.dylib Godot.app/Contents/Frameworks/libMoltenVK.dylib
 
 Compiling a headless/server build
 ---------------------------------


### PR DESCRIPTION
Docs had "libs", actual path in the SDK is "lib"

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

All pull requests for Godot 3 should usually go into `master`.
-->
